### PR TITLE
Add auto-allocation for bgpvpn creation endpoint.

### DIFF
--- a/networking_bgpvpn/neutron/db/bgpvpn_db.py
+++ b/networking_bgpvpn/neutron/db/bgpvpn_db.py
@@ -18,6 +18,7 @@ from oslo_log import log
 from oslo_utils import uuidutils
 import sqlalchemy as sa
 from sqlalchemy import and_
+from sqlalchemy import or_
 from sqlalchemy import orm
 from sqlalchemy.orm import exc
 
@@ -316,6 +317,17 @@ class BGPVPNPluginDb(object):
                      BGPVPNRBAC.action == rbac_db_models.ACCESS_SHARED,
                      BGPVPNRBAC.target_tenant.in_(
                          ['*', context.tenant_id]))).count() != 0)
+
+    @db_api.CONTEXT_READER
+    def get_allocated_targets(self, context):
+        query = context.session.query(BGPVPN.route_targets,
+                                      BGPVPN.import_targets,
+                                      BGPVPN.export_targets)
+        query = query.filter(or_(BGPVPN.route_targets.isnot(None),
+                                 BGPVPN.import_targets.isnot(None),
+                                 BGPVPN.export_targets.isnot(None)))
+        # save route/import/export targets without duplicates
+        return {r for row in query.all() for r in row if r}
 
     @db_api.CONTEXT_WRITER
     def create_bgpvpn(self, context, bgpvpn):

--- a/networking_bgpvpn/neutron/opts.py
+++ b/networking_bgpvpn/neutron/opts.py
@@ -10,8 +10,49 @@
 #  License for the specific language governing permissions and limitations
 #  under the License.
 
+import itertools
+
 from neutron.conf.services import provider_configuration
 from oslo_config import cfg
+
+
+BGPVPN_CONFIG_OPTS = [
+    cfg.StrOpt('region_asn',
+               default=None,
+               help='The unique region 4-byte ASn identifier for'
+                    'import/export/route targets. Should be in dotted notation'
+                    ' <ASN>.<Number>'),
+    cfg.StrOpt('target_id_range',
+               default='300-1000',
+               help='The range of unique numbers for import/export/route '
+                    'targets'),
+    cfg.BoolOpt('import_target_auto_allocation',
+                default=False,
+                help='This option enables auto-allocation for import targets'
+                     'for a new bgpvpns created with empty import_targets '
+                     'field.'),
+    cfg.BoolOpt('export_target_auto_allocation',
+                default=False,
+                help='This option enables auto-allocation for export targets'
+                     'for a new bgpvpns created with empty export_targets '
+                     'field.'),
+    cfg.BoolOpt('route_target_auto_allocation',
+                default=False,
+                help='This option enables auto-allocation for route targets'
+                     'for a new bgpvpns created with empty route_targets '
+                     'field.'),
+]
+
+
+def register_bgpvpn_options(cfg=cfg.CONF):
+    cfg.register_opts(BGPVPN_CONFIG_OPTS, group='bgpvpn')
+
+
+def list_bgpvpn_opts():
+    return [
+        ('bgpvpn', itertools.chain(
+            BGPVPN_CONFIG_OPTS)),
+    ]
 
 
 def list_service_provider():

--- a/networking_bgpvpn/tests/unit/db/test_db.py
+++ b/networking_bgpvpn/tests/unit/db/test_db.py
@@ -248,6 +248,28 @@ class BgpvpnDBTestCase(test_plugin.BgpvpnTestCaseMixin):
         bgpvpn = self.plugin_db.get_bgpvpn(ctx, bgpvpn['id'])
         self.assertEqual(True, bgpvpn['shared'])
 
+    def test_get_allocated_targets(self):
+        target_fields = ["route_targets", "import_targets", "export_targets"]
+        for i in range(3):
+            for f in range(3):
+                body = {
+                    "tenant_id": self.ctx.tenant_id,
+                    "type": "l3",
+                    "name": "",
+                    "route_targets": [],
+                    "import_targets": [],
+                    "export_targets": [],
+                }
+                body[target_fields[f]] = ["6451%s:%s" % (i, f)]
+                self.plugin_db.create_bgpvpn(
+                    self.ctx,
+                    body
+                )
+        alloc_targets = self.plugin_db.get_allocated_targets(self.ctx)
+        self.assertEqual({'64511:1', '64510:2', '64512:0', '64510:1',
+                          '64512:2', '64510:0', '64511:0', '64511:2',
+                          '64512:1'}, alloc_targets)
+
     def test_db_associate_disassociate_net(self):
         with self.network() as net:
             net_id = net['network']['id']

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ heat.constraints =
 neutron.service_plugins =
     bgpvpn = networking_bgpvpn.neutron.services.plugin:BGPVPNPlugin
 oslo.config.opts =
+    networking-bgpvpn.bgpvpn = networking_bgpvpn.neutron.opts:list_bgpvpn_opts
     networking-bgpvpn.service_provider = networking_bgpvpn.neutron.opts:list_service_provider
 oslo.config.opts.defaults =
     networking-bgpvpn.service_provider = networking_bgpvpn.neutron.opts:set_service_provider_default


### PR DESCRIPTION
This commit adds auto-allocation system for bgpvpn creation. If the
special setting are enabled the service plugin will allocate
import/export/route targets for new bgpvpn in case if they were not
passed in request body.

The algorithm how targets will be choosen:
1. 4-byte ASn will be converted from dotted notation to full number
    by formula (<AS> * 65536) + <Number>. For example if setting
   `region_asn` has value 65130.4 the result ASn will be (65130 *
   65536) + 4 = 4268359684;
2. unique identifier for this bgpvpn will be found from the range of
    option `target_id_range`;
3. the ASn from first step will be used for import/export/route fields
    depending on what option was enabled from the list:
    import_target_auto_allocation, export_target_auto_allocation,
    route_target_auto_allocation and unique identifier will be added
    after colon like: 4268359684:100.

As result, we will have unique auto-allocated targets when the option
enabled.