### PR TITLE
[tox] add allowlist_externals where necessary and fix dashboard test

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,6 +4,8 @@
 sphinx>=2.0.0,!=2.1.0 # BSD
 openstackdocstheme>=2.2.1 # Apache-2.0
 reno>=3.1.0 # Apache-2.0
+oslo.config>=5.2.0 # Apache-2.0
+oslo.policy>=3.12.0 # Apache-2.0
 
 sphinxcontrib-blockdiag>=1.5.4 # BSD
 sphinxcontrib-seqdiag>=0.8.4 # BSD

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,8 +10,7 @@ psycopg2>=2.8.5 # LGPL/ZPL
 PyMySQL>=0.7.6 # MIT License
 WebOb>=1.8.2 # MIT
 oslotest>=3.2.0 # Apache-2.0
-astroid==2.1.0 # LGPLv2.1
-pylint==2.2.0 # GPLv2
+pylint==2.5.3 # GPLv2
 pytest>=5.3.5 # MIT
 stestr>=1.0.0 # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ skipsdist = True
 ignore_basepython_conflict = True
 
 [testenv]
-usedevelop = True
+usedevelop = False
+skipsdist = False
 basepython = python3.8
 setenv =
    OS_LOG_CAPTURE={env:OS_LOG_CAPTURE:true}
@@ -19,7 +20,7 @@ deps = -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requi
        git+https://github.com/sapcc/neutron@{env:OS_SAP_RELEASE}#egg=neutron
 commands =
            stestr run {posargs}
-           python {toxinidir}/tools/django-manage.py test bgpvpn_dashboard
+           python {toxinidir}/tools/django-manage.py test {envsitepackagesdir}/bgpvpn_dashboard
 
 [testenv:releasenotes]
 deps = -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/{env:OS_SAP_RELEASE}/upper-constraints.txt}
@@ -38,6 +39,8 @@ commands =
     neutron-db-manage --subproject networking-bgpvpn --database-connection sqlite:// check_migration
     {[testenv:genconfig]commands}
     {[testenv:genpolicy]commands}
+allowlist_externals =
+    {toxinidir}/tools/generate_config_file_samples.sh
 
 [testenv:dsvm]
 setenv = OS_FAIL_ON_MISSING_DEPS=1
@@ -91,6 +94,8 @@ commands = oslo_debug_helper -t networking_bgpvpn/tests/unit {posargs}
 
 [testenv:genconfig]
 commands = {toxinidir}/tools/generate_config_file_samples.sh
+allowlist_externals =
+    {toxinidir}/tools/generate_config_file_samples.sh
 
 [testenv:genpolicy]
 commands = oslopolicy-sample-generator --config-file=etc/oslo-policy-generator/policy.conf


### PR DESCRIPTION
This patch cherry-picks changes made upstream[^1] to improve compatibly with tox >= v4 in order to fix the Github Actions pipeline.

[^1]: https://github.com/openstack/networking-bgpvpn/commit/d259ea394b6cd7cc7e142ea15ebac10b4b05756c