### PR TITLE
Set service type when registering provider config

### DIFF
--- a/networking_bgpvpn/neutron/services/plugin.py
+++ b/networking_bgpvpn/neutron/services/plugin.py
@@ -62,7 +62,8 @@ class BGPVPNPlugin(bgpvpn.BGPVPNPluginBase,
         service_type_manager = st_db.ServiceTypeManager.get_instance()
         service_type_manager.add_provider_configuration(
             SERVICE_PROVIDER_TYPE,
-            pconf.ProviderConfiguration('networking_bgpvpn'))
+            pconf.ProviderConfiguration('networking_bgpvpn',
+                                        SERVICE_PROVIDER_TYPE))
 
         # Load the default driver
         drivers, default_provider = service_base.load_drivers(


### PR DESCRIPTION
When registering the provider configuration with the service type manager we need to specify a service type for ProviderConfiguration(), as described in the Neutron Contributors documentation[0]. If this is not done it might lead to duplicate service providers configuration, as the ProviderConfiguration no longer filters out other services.

[0] https://docs.openstack.org/neutron/latest/contributor/contribute.html#service-providers

Change-Id: I90deb35bb6ed843aa132171907c9efe2a09fee99