### PR TITLE
Ensure route target uniqueness during concurrent BGPVPN creation

### DIFF
--- a/networking_bgpvpn/neutron/db/bgpvpn_db.py
+++ b/networking_bgpvpn/neutron/db/bgpvpn_db.py
@@ -327,7 +327,12 @@ class BGPVPNPluginDb():
                                  BGPVPN.import_targets.isnot(None),
                                  BGPVPN.export_targets.isnot(None)))
         # save route/import/export targets without duplicates
-        return {r for row in query.all() for r in row if r}
+        allocated_route_targets = set()
+        for row in query.all():
+            for r in row:
+                if r:
+                    allocated_route_targets.update(r.split(','))
+        return allocated_route_targets
 
     @db_api.CONTEXT_WRITER
     def create_bgpvpn(self, context, bgpvpn):

--- a/networking_bgpvpn/neutron/db/bgpvpn_db.py
+++ b/networking_bgpvpn/neutron/db/bgpvpn_db.py
@@ -362,6 +362,19 @@ class BGPVPNPluginDb():
                 context, obj, fields=fields) for obj in objs]
 
     @db_api.CONTEXT_READER
+    def count_bgpvpns_by_route_targets(self, context, route_targets):
+        query = context.session.query(BGPVPN.id)
+
+        filters = []
+        for rt in route_targets:
+            filters.append(BGPVPN.import_targets.like(f"%{rt}%"))
+            filters.append(BGPVPN.export_targets.like(f"%{rt}%"))
+            filters.append(BGPVPN.route_targets.like(f"%{rt}%"))
+
+        query = query.filter(or_(*filters))
+        return query.count()
+
+    @db_api.CONTEXT_READER
     def _get_bgpvpn(self, context, id):
         try:
             return model_query.get_by_id(context, BGPVPN, id)
@@ -393,6 +406,7 @@ class BGPVPNPluginDb():
             bgpvpn_db.update(bgpvpn)
         return self._make_bgpvpn_dict(context, bgpvpn_db)
 
+    @db_api.retry_if_session_inactive()
     @db_api.CONTEXT_WRITER
     def delete_bgpvpn(self, context, id):
         bgpvpn_db = self._get_bgpvpn(context, id)

--- a/networking_bgpvpn/neutron/db/bgpvpn_db.py
+++ b/networking_bgpvpn/neutron/db/bgpvpn_db.py
@@ -368,8 +368,15 @@ class BGPVPNPluginDb():
 
     @db_api.CONTEXT_READER
     def count_bgpvpns_by_route_targets(self, context, route_targets):
-        query = context.session.query(BGPVPN.id)
+        query = context.session.query(BGPVPN.id, BGPVPN.route_targets,
+                                BGPVPN.import_targets, BGPVPN.export_targets)
 
+        # route_targets is stored as a VARCHAR in the database
+        # e.g. '123:4567,123:4568'
+        # The current search uses fuzzy matching
+        # (e.g. '123:456' would match '123:4567')
+        # After running the fuzzy search, we need to filter
+        # the results to keep only exact matches
         filters = []
         for rt in route_targets:
             filters.append(BGPVPN.import_targets.like(f"%{rt}%"))
@@ -377,7 +384,16 @@ class BGPVPNPluginDb():
             filters.append(BGPVPN.route_targets.like(f"%{rt}%"))
 
         query = query.filter(or_(*filters))
-        return query.count()
+
+        matching_bgpvpns_db = query.all()
+        counter = 0
+        for rt in utils.rtrd_str2list(route_targets):
+            for bgpvpn_db in matching_bgpvpns_db:
+                for key in 'route', 'import', 'export':
+                    if rt in utils.rtrd_str2list(bgpvpn_db[f'{key}_targets']):
+                        counter += 1
+                        break
+        return counter
 
     @db_api.CONTEXT_READER
     def _get_bgpvpn(self, context, id):

--- a/networking_bgpvpn/neutron/services/plugin.py
+++ b/networking_bgpvpn/neutron/services/plugin.py
@@ -199,13 +199,11 @@ class BGPVPNPlugin(bgpvpn.BGPVPNPluginBase,
                             bgpvpn['export_targets'] = [target]
                         if self.bgpvpn_config.route_target_auto_allocation:
                             bgpvpn['route_targets'] = [target]
-                        return True
             else:
                 msg = ('Targets fields required. One of the fields: '
                        'export_targets, import_targets, route_target must be '
                        'passed.')
                 raise n_exc.BadRequest(resource='bgpvpn', msg=msg)
-        return False
 
     def _available_targets(self):
         if not self._is_targets_auto_allocation_enabled():
@@ -249,8 +247,8 @@ class BGPVPNPlugin(bgpvpn.BGPVPNPluginBase,
     @db_api.retry_if_session_inactive()
     def create_bgpvpn(self, context, bgpvpn):
         bgpvpn = bgpvpn['bgpvpn']
-        auto_allocated = self._validate_targets(context, bgpvpn)
-        return self.driver.create_bgpvpn(context, bgpvpn, auto_allocated)
+        self._validate_targets(context, bgpvpn)
+        return self.driver.create_bgpvpn(context, bgpvpn)
 
     def get_bgpvpns(self, context, filters=None, fields=None):
         return self.driver.get_bgpvpns(context, filters, fields)

--- a/networking_bgpvpn/neutron/services/plugin.py
+++ b/networking_bgpvpn/neutron/services/plugin.py
@@ -25,6 +25,7 @@ from neutron_lib.callbacks import events
 from neutron_lib.callbacks import registry
 from neutron_lib.callbacks import resources
 from neutron_lib import constants as const
+from neutron_lib.db import api as db_api
 from neutron_lib import exceptions as n_exc
 from neutron_lib.plugins import constants as plugin_constants
 from neutron_lib.plugins import directory
@@ -192,12 +193,13 @@ class BGPVPNPlugin(bgpvpn.BGPVPNPluginBase,
                             bgpvpn['export_targets'] = [target]
                         if self.bgpvpn_config.route_target_auto_allocation:
                             bgpvpn['route_targets'] = [target]
-                        return
+                        return True
             else:
                 msg = ('Targets fields required. One of the fields: '
                        'export_targets, import_targets, route_target must be '
                        'passed.')
                 raise n_exc.BadRequest(resource='bgpvpn', msg=msg)
+        return False
 
     def _available_targets(self):
         if not self._is_targets_auto_allocation_enabled():
@@ -238,10 +240,11 @@ class BGPVPNPlugin(bgpvpn.BGPVPNPluginBase,
     def get_plugin_description(self):
         return "Neutron BGPVPN Service Plugin"
 
+    @db_api.retry_if_session_inactive()
     def create_bgpvpn(self, context, bgpvpn):
         bgpvpn = bgpvpn['bgpvpn']
-        self._validate_targets(context, bgpvpn)
-        return self.driver.create_bgpvpn(context, bgpvpn)
+        auto_allocated = self._validate_targets(context, bgpvpn)
+        return self.driver.create_bgpvpn(context, bgpvpn, auto_allocated)
 
     def get_bgpvpns(self, context, filters=None, fields=None):
         return self.driver.get_bgpvpns(context, filters, fields)

--- a/networking_bgpvpn/neutron/services/plugin.py
+++ b/networking_bgpvpn/neutron/services/plugin.py
@@ -14,6 +14,7 @@
 #    under the License.
 
 import copy
+import random
 
 from neutron.db import servicetype_db as st_db
 from neutron.objects import base
@@ -185,7 +186,12 @@ class BGPVPNPlugin(bgpvpn.BGPVPNPluginBase,
             if self._is_targets_auto_allocation_enabled():
                 alloc_targets = self.driver.bgpvpn_db.get_allocated_targets(
                     context)
-                for target in self.bgpvpn_available_targets:
+
+                # Randomize how free route targets get allocated
+                _available_targets = copy.copy(self.bgpvpn_available_targets)
+                random.shuffle(_available_targets)
+
+                for target in _available_targets:
                     if target not in alloc_targets:
                         if self.bgpvpn_config.import_target_auto_allocation:
                             bgpvpn['import_targets'] = [target]

--- a/networking_bgpvpn/neutron/services/service_drivers/driver_api.py
+++ b/networking_bgpvpn/neutron/services/service_drivers/driver_api.py
@@ -17,10 +17,14 @@ import abc
 import copy
 
 from neutron_lib.db import api as db_api
+from oslo_db import exception as db_exc
+from oslo_log import log
 
 from networking_bgpvpn.neutron.db import bgpvpn_db
 from networking_bgpvpn.neutron.extensions \
     import bgpvpn_routes_control as bgpvpn_rc
+
+LOG = log.getLogger(__name__)
 
 
 class BGPVPNDriverBase(metaclass=abc.ABCMeta):
@@ -102,11 +106,39 @@ class BGPVPNDriverDBMixin(BGPVPNDriverBase, metaclass=abc.ABCMeta):
         super().__init__(*args, **kwargs)
         self.bgpvpn_db = bgpvpn_db.BGPVPNPluginDb()
 
-    def create_bgpvpn(self, context, bgpvpn):
+    def create_bgpvpn(self, context, bgpvpn, auto_allocated=False):
         with db_api.CONTEXT_WRITER.using(context):
             bgpvpn = self.bgpvpn_db.create_bgpvpn(
                 context, bgpvpn)
             self.create_bgpvpn_precommit(context, bgpvpn)
+
+        if auto_allocated:
+            # Check for duplicate as auto allocation is not thread safe
+            # It holds: import_targets == export_targets
+            # Auto allocation does not use route_targets
+            count = self.bgpvpn_db.count_bgpvpns_by_route_targets(
+                            context,
+                            route_targets=bgpvpn.get("import_targets"))
+            if count > 1:
+                LOG.info(
+                    "Duplicate route target(s) %s detected for "
+                    "newly created BGPVPN %s. "
+                    "Auto allocation may have collided with another"
+                    "concurrent request. "
+                    "Initiating cleanup and retry.",
+                    bgpvpn.get("import_targets"),
+                    bgpvpn.get("id"),
+                )
+                try:
+                    self.delete_bgpvpn(context, bgpvpn.get("id"))
+                except bgpvpn.BGPVPNNotFound:
+                    LOG.info(
+                        "BGPVPN %s not found during duplicate cleanup — "
+                        "it may have already been deleted by another process.",
+                        bgpvpn.get("id"),
+                    )
+                raise db_exc.DBDuplicateEntry()
+
         self.create_bgpvpn_postcommit(context, bgpvpn)
         return bgpvpn
 

--- a/networking_bgpvpn/neutron/services/service_drivers/driver_api.py
+++ b/networking_bgpvpn/neutron/services/service_drivers/driver_api.py
@@ -106,13 +106,12 @@ class BGPVPNDriverDBMixin(BGPVPNDriverBase, metaclass=abc.ABCMeta):
         super().__init__(*args, **kwargs)
         self.bgpvpn_db = bgpvpn_db.BGPVPNPluginDb()
 
-    def create_bgpvpn(self, context, bgpvpn, auto_allocated=False):
+    def create_bgpvpn(self, context, bgpvpn):
         with db_api.CONTEXT_WRITER.using(context):
             bgpvpn = self.bgpvpn_db.create_bgpvpn(
                 context, bgpvpn)
             self.create_bgpvpn_precommit(context, bgpvpn)
 
-        if auto_allocated:
             # Check for duplicate as auto allocation is not thread safe
             # It holds: import_targets == export_targets
             # Auto allocation does not use route_targets
@@ -129,14 +128,6 @@ class BGPVPNDriverDBMixin(BGPVPNDriverBase, metaclass=abc.ABCMeta):
                     bgpvpn.get("import_targets"),
                     bgpvpn.get("id"),
                 )
-                try:
-                    self.delete_bgpvpn(context, bgpvpn.get("id"))
-                except bgpvpn.BGPVPNNotFound:
-                    LOG.info(
-                        "BGPVPN %s not found during duplicate cleanup — "
-                        "it may have already been deleted by another process.",
-                        bgpvpn.get("id"),
-                    )
                 raise db_exc.DBDuplicateEntry()
 
         self.create_bgpvpn_postcommit(context, bgpvpn)

--- a/networking_bgpvpn/tests/unit/db/test_db.py
+++ b/networking_bgpvpn/tests/unit/db/test_db.py
@@ -12,7 +12,10 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import copy
+
 from oslo_utils import uuidutils
+from unittest import mock
 
 from neutron.db import rbac_db_models
 from neutron_lib.api.definitions import bgpvpn_routes_control as bgpvpn_rc_def
@@ -28,6 +31,7 @@ from networking_bgpvpn.neutron.extensions.bgpvpn import BGPVPNNetAssocNotFound
 from networking_bgpvpn.neutron.extensions.bgpvpn import BGPVPNNotFound
 from networking_bgpvpn.neutron.services.common import constants
 from networking_bgpvpn.neutron.services.common import utils
+from networking_bgpvpn.neutron.services import plugin
 from networking_bgpvpn.tests.unit.services import test_plugin
 
 
@@ -538,6 +542,52 @@ class BgpvpnDBTestCase(test_plugin.BgpvpnTestCaseMixin):
                 {'port_association': {'routes': []}}
             )
             self.assertEqual(0, len(res['port_association']['routes']))
+
+    @mock.patch.object(plugin.BGPVPNPlugin,
+                       '_validate_targets')
+    def test_count_bgpvpns_by_route_targets(self, mock_validate_targets):
+        mock_validate_targets.return_value = False
+
+        template = {'bgpvpn': {'name': 'bgpvpn1',
+                    'type': 'l3',
+                    'route_targets': [],
+                    'import_targets': [],
+                    "export_targets": [],
+                    'tenant_id': self._tenant_id}}
+
+        BGPVPN_A = copy.deepcopy(template)
+        BGPVPN_B = copy.deepcopy(template)
+        BGPVPN_C = copy.deepcopy(template)
+
+        route_target_1 = ['1234:56']
+        route_target_2 = ['2234:56']
+
+        BGPVPN_A["bgpvpn"]['route_targets'] = route_target_1
+        BGPVPN_B["bgpvpn"]["route_targets"] = route_target_1
+        BGPVPN_C["bgpvpn"]["route_targets"] = route_target_2
+
+        with self.bgpvpn(data=BGPVPN_A):
+            with self.bgpvpn(data=BGPVPN_B):
+                with self.bgpvpn(data=BGPVPN_C) as bgpvpn_c:
+                    # Match BGPVPN with none matching route_target
+                    count_1 = self.plugin_db.count_bgpvpns_by_route_targets(
+                        self.ctx, route_target_1)
+                    self.assertEqual(2, count_1)
+
+                    # Match BGPVPN with matching route_target
+                    count_2 = self.plugin_db.count_bgpvpns_by_route_targets(
+                        self.ctx, route_target_2)
+                    self.assertEqual(1, count_2)
+
+                    # Match BGPVPN with single matching route_target
+                    route_target_3 = ['1234:56', '2234:56']
+                    bgpvpn_c["bgpvpn"]["route_targets"] = route_target_3
+                    id = bgpvpn_c["bgpvpn"]["id"]
+                    self.plugin_db.update_bgpvpn(self.ctx, id,
+                                                 bgpvpn_c["bgpvpn"])
+                    count_3 = self.plugin_db.count_bgpvpns_by_route_targets(
+                        self.ctx, route_target_1)
+                    self.assertEqual(3, count_3)
 
 
 class BgpvpnDBTestCaseWithVNI(BgpvpnDBTestCase):

--- a/networking_bgpvpn/tests/unit/db/test_db.py
+++ b/networking_bgpvpn/tests/unit/db/test_db.py
@@ -274,6 +274,21 @@ class BgpvpnDBTestCase(test_plugin.BgpvpnTestCaseMixin):
                           '64512:2', '64510:0', '64511:0', '64511:2',
                           '64512:1'}, alloc_targets)
 
+    def test_get_allocated_targets_for_multiple_bgpvpn_targets(self):
+        route_targets = ["1000:1000", "2000:2000"]
+        import_targets = ["1000:1000", "2000:2000", "3000:3000"]
+
+        bgpvpn_1 = copy.deepcopy(self.bgpvpn_data)
+        bgpvpn_1['bgpvpn']['route_targets'] = route_targets
+        bgpvpn_1['bgpvpn']['import_targets'] = import_targets
+        bgpvpn_1['bgpvpn']['export_targets'] = import_targets
+
+        self.plugin_db.create_bgpvpn(self.ctx, bgpvpn_1['bgpvpn'])
+
+        alloc_targets = self.plugin_db.get_allocated_targets(self.ctx)
+        self.assertEqual({'1000:1000', '2000:2000', '3000:3000'},
+                         alloc_targets)
+
     def test_db_associate_disassociate_net(self):
         with self.network() as net:
             net_id = net['network']['id']

--- a/networking_bgpvpn/tests/unit/db/test_db.py
+++ b/networking_bgpvpn/tests/unit/db/test_db.py
@@ -575,7 +575,8 @@ class BgpvpnDBTestCase(test_plugin.BgpvpnTestCaseMixin):
         BGPVPN_C = copy.deepcopy(template)
 
         route_target_1 = ['1234:56']
-        route_target_2 = ['2234:56']
+        # test exact match after running a fuzzy search
+        route_target_2 = ['1234:567']
 
         BGPVPN_A["bgpvpn"]['route_targets'] = route_target_1
         BGPVPN_B["bgpvpn"]["route_targets"] = route_target_1

--- a/networking_bgpvpn/tests/unit/services/test_plugin.py
+++ b/networking_bgpvpn/tests/unit/services/test_plugin.py
@@ -24,6 +24,8 @@ from neutron_lib.plugins import directory
 from oslo_config import cfg
 from oslo_utils import uuidutils
 
+from oslo_db.exception import DBDuplicateEntry
+
 from neutron.api import extensions as api_extensions
 from neutron.db import servicetype_db as sdb
 from neutron import extensions as n_extensions
@@ -1002,9 +1004,7 @@ class TestBGPVPNServiceDriverDB(BgpvpnTestCaseMixin):
             mock_create_postcommit.assert_called_once_with(
                 mock.ANY, self.converted_data['bgpvpn'])
 
-    @mock.patch.object(plugin.BGPVPNPlugin,
-                       '_validate_targets')
-    def test_create_bgpvpn_duplicate_rts(self, mock_validate_targets):
+    def test_create_bgpvpn_duplicate_rts(self):
         import_targets = ["1000000000:1111"]
         export_targets = ["2000000000:2222"]
 
@@ -1017,9 +1017,7 @@ class TestBGPVPNServiceDriverDB(BgpvpnTestCaseMixin):
         bgpvpn_2["bgpvpn"]['import_targets'] = import_targets
         bgpvpn_2["bgpvpn"]['export_targets'] = export_targets
 
-        mock_validate_targets.return_value = True
-
-        # Only retrie once if bgpvpn creation intentionally fails
+        # Only retry once if bgpvpn creation intentionally fails
         retry_fixture = fixture.DBRetryErrorsFixture(max_retries=1)
         retry_fixture.setUp()
 
@@ -1027,13 +1025,6 @@ class TestBGPVPNServiceDriverDB(BgpvpnTestCaseMixin):
             with self.bgpvpn(data=bgpvpn_1):
                 with self.bgpvpn(data=bgpvpn_2):
                     pass
-
-        bgpvpn_3 = copy.deepcopy(self.bgpvpn_data)
-        bgpvpn_3["bgpvpn"]['route_targets'] = []
-        bgpvpn_3["bgpvpn"]['import_targets'] = ["1000000000:2000"]
-        bgpvpn_3["bgpvpn"]['export_targets'] = ["1000000000:2000"]
-        with self.bgpvpn(data=bgpvpn_3) as b:
-            print(b)
 
     def test_create_bgpvpn_precommit_fails(self):
         with mock.patch.object(driver_api.BGPVPNDriver,

--- a/networking_bgpvpn/tests/unit/services/test_plugin.py
+++ b/networking_bgpvpn/tests/unit/services/test_plugin.py
@@ -33,6 +33,7 @@ from neutron.tests.unit.extensions import test_l3
 from neutron.tests.unit.extensions.test_l3 import TestL3NatServicePlugin
 from neutron_lib.api.definitions import bgpvpn as bgpvpn_def
 from neutron_lib.api.definitions import bgpvpn_vni as bgpvpn_vni_def
+from neutron_lib import fixture
 
 from networking_bgpvpn.neutron.db import bgpvpn_db
 from networking_bgpvpn.neutron import extensions
@@ -126,6 +127,8 @@ class BgpvpnTestCaseMixin(test_db_base_plugin_v2.NeutronDbPluginV2TestCase,
         self.bgpvpn_data = {'bgpvpn': {'name': 'bgpvpn1',
                                        'type': 'l3',
                                        'route_targets': ['1234:56'],
+                                       'import_targets': [],
+                                       "export_targets": [],
                                        'tenant_id': self._tenant_id}}
         self.converted_data = copy.copy(self.bgpvpn_data)
         self.converted_data['bgpvpn'].update({'export_targets': [],
@@ -794,8 +797,9 @@ class TestBGPVPNServicePlugin(BgpvpnTestCaseMixin):
         with self.network() as net, \
                 self.subnet(network={'network': net['network']}) as subnet, \
                 self.port(subnet={'subnet': subnet['subnet']}) as port, \
-                self.bgpvpn() as bgpvpn, \
-                self.bgpvpn(tenant_id="notus") as bgpvpn_other:
+                self.bgpvpn(route_targets=['1234:56']) as bgpvpn, \
+                self.bgpvpn(tenant_id="notus",
+                            route_targets=['78:56']) as bgpvpn_other:
 
             data = {'port_association': {
                     'port_id': port['port']['id'],
@@ -906,8 +910,9 @@ class TestBGPVPNServicePlugin(BgpvpnTestCaseMixin):
         with self.network() as net, \
                 self.subnet(network={'network': net['network']}) as subnet, \
                 self.port(subnet={'subnet': subnet['subnet']}) as port, \
-                self.bgpvpn() as bgpvpn, \
-                self.bgpvpn(tenant_id="not-us") as bgpvpn_other, \
+                self.bgpvpn(route_targets=['1234:56']) as bgpvpn, \
+                self.bgpvpn(tenant_id="not-us",
+                            route_targets=['78:56']) as bgpvpn_other, \
                 self.assoc_port(bgpvpn['bgpvpn']['id'],
                                 port['port']['id']) as port_assoc:
 
@@ -936,8 +941,8 @@ class TestBGPVPNServicePlugin(BgpvpnTestCaseMixin):
         with self.network() as net, \
                 self.subnet(network={'network': net['network']}) as subnet, \
                 self.port(subnet={'subnet': subnet['subnet']}) as port, \
-                self.bgpvpn(type='l2') as bgpvpn_l2, \
-                self.bgpvpn(type='l3') as bgpvpn_l3, \
+                self.bgpvpn(type='l2', route_targets=['12:56']) as bgpvpn_l2, \
+                self.bgpvpn(type='l3', route_targets=['78:56']) as bgpvpn_l3, \
                 self.assoc_port(bgpvpn_l2['bgpvpn']['id'],
                                 port['port']['id']) as port_assoc:
 
@@ -988,6 +993,39 @@ class TestBGPVPNServiceDriverDB(BgpvpnTestCaseMixin):
                 mock.ANY, self.converted_data['bgpvpn'])
             mock_create_postcommit.assert_called_once_with(
                 mock.ANY, self.converted_data['bgpvpn'])
+
+    @mock.patch.object(plugin.BGPVPNPlugin,
+                       '_validate_targets')
+    def test_create_bgpvpn_duplicate_rts(self, mock_validate_targets):
+        import_targets = ["1000000000:1111"]
+        export_targets = ["2000000000:2222"]
+
+        bgpvpn_1 = copy.deepcopy(self.bgpvpn_data)
+        bgpvpn_1["bgpvpn"]['import_targets'] = import_targets
+        bgpvpn_1["bgpvpn"]['export_targets'] = export_targets
+
+        # Create bgpvpn with same import/export targets
+        bgpvpn_2 = copy.deepcopy(self.bgpvpn_data)
+        bgpvpn_2["bgpvpn"]['import_targets'] = import_targets
+        bgpvpn_2["bgpvpn"]['export_targets'] = export_targets
+
+        mock_validate_targets.return_value = True
+
+        # Only retrie once if bgpvpn creation intentionally fails
+        retry_fixture = fixture.DBRetryErrorsFixture(max_retries=1)
+        retry_fixture.setUp()
+
+        with (unittest.TestCase.assertRaises(self, webob.exc.HTTPClientError)):
+            with self.bgpvpn(data=bgpvpn_1):
+                with self.bgpvpn(data=bgpvpn_2):
+                    pass
+
+        bgpvpn_3 = copy.deepcopy(self.bgpvpn_data)
+        bgpvpn_3["bgpvpn"]['route_targets'] = []
+        bgpvpn_3["bgpvpn"]['import_targets'] = ["1000000000:2000"]
+        bgpvpn_3["bgpvpn"]['export_targets'] = ["1000000000:2000"]
+        with self.bgpvpn(data=bgpvpn_3) as b:
+            print(b)
 
     def test_create_bgpvpn_precommit_fails(self):
         with mock.patch.object(driver_api.BGPVPNDriver,

--- a/networking_bgpvpn/tests/unit/services/test_plugin.py
+++ b/networking_bgpvpn/tests/unit/services/test_plugin.py
@@ -310,6 +310,10 @@ class TestBGPVPNServicePlugin(BgpvpnTestCaseMixin):
                 self.bgpvpn(export_targets=[],
                             import_targets=[],
                             route_targets=[]) as bgpvpn_3:
+
+            used_allocations = [*bgpvpn_1['bgpvpn']["import_targets"],
+                                *bgpvpn_1['bgpvpn']["export_targets"]]
+
             # check that auto-allocation disabled for non-empty fields
             self.assertEqual([],
                              bgpvpn_1['bgpvpn']['route_targets'])
@@ -317,21 +321,25 @@ class TestBGPVPNServicePlugin(BgpvpnTestCaseMixin):
                              bgpvpn_1['bgpvpn']['import_targets'])
             self.assertEqual(['4268359684:300'],
                              bgpvpn_1['bgpvpn']['export_targets'])
+
             # check that auto-allocation choose only available targets
-            self.assertEqual(['4268359684:301'],
-                             bgpvpn_2['bgpvpn']['route_targets'])
-            self.assertEqual(['4268359684:301'],
-                             bgpvpn_2['bgpvpn']['import_targets'])
-            self.assertEqual(['4268359684:301'],
-                             bgpvpn_2['bgpvpn']['export_targets'])
+            for alloc in used_allocations:
+                self.assertNotEqual(alloc,
+                                 bgpvpn_2['bgpvpn']['route_targets'])
+                self.assertNotEqual(alloc,
+                                 bgpvpn_2['bgpvpn']['import_targets'])
+                self.assertNotEqual(alloc,
+                                 bgpvpn_2['bgpvpn']['export_targets'])
+
             # check that auto-allocation knows about manual target
-            # 4268359684:302 and will not use it
-            self.assertEqual(['4268359684:303'],
-                             bgpvpn_3['bgpvpn']['route_targets'])
-            self.assertEqual(['4268359684:303'],
-                             bgpvpn_3['bgpvpn']['import_targets'])
-            self.assertEqual(['4268359684:303'],
-                             bgpvpn_3['bgpvpn']['export_targets'])
+            used_allocations.append(*bgpvpn_2['bgpvpn']['route_targets'])
+            for alloc in used_allocations:
+                self.assertNotEqual(alloc,
+                                 bgpvpn_3['bgpvpn']['route_targets'])
+                self.assertNotEqual(alloc,
+                                 bgpvpn_3['bgpvpn']['import_targets'])
+                self.assertNotEqual(alloc,
+                                 bgpvpn_3['bgpvpn']['export_targets'])
 
     def test_bgpvpn_create_without_targets(self):
         with mock.patch.object(self.bgpvpn_plugin,


### PR DESCRIPTION
Route targets must be unique across all BGPVPN objects. When multiple processes or API calls attempt to create BGPVPNs concurrently, there is a risk that the same route target could be assigned more than once since no database-level uniqueness constraint is enforced for these attributes (route_targets, import_rt, export_rt).

This commit introduces an additional check after BGPVPN creation to ensure that route target uniqueness is maintained. If a conflict is detected, the transaction is rolled back, and the operation is retried (up to 20 times).