### PR TITLE
Drop optional dependencies from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,6 @@ debtcollector>=1.19.0 # Apache-2.0
 # OpenStack CI will install the following projects from git
 # if they are in the required-projects list for a job:
 neutron>=23.0.0.0b2 # Apache-2.0
-networking-bagpipe>=12.0.0.0rc1 # Apache-2.0
-horizon>=17.1.0 # Apache-2.0
 
 # The comment below indicates this project repo is current with neutron-lib
 # and should receive neutron-lib consumption patches as they are released

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ data_files =
 # For tox testing, we have these in test-requirements.txt too
 # as tox extras installation does not honor constraints file.
 bagpipe =
-    networking-bagpipe>=9.0.0 # Apache-2.0
+    networking-bagpipe>=12.0.0 # Apache-2.0
 horizon =
     horizon>=17.1.0 # Apache-2.0
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,7 +19,7 @@ isort==4.3.21 # MIT
 # if they are in the required-projects list for a job.
 # Installation by 'extras' in tox.ini does not honor upper-constraints,
 # so we specify the same here to ensure upper-constraints.
-networking-bagpipe>=12.0.0.0rc1 # Apache-2.0
+networking-bagpipe>=12.0.0.0 # Apache-2.0
 horizon>=17.1.0 # Apache-2.0
 
 # This is necessary as pecan dropped this dependency

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,11 @@ envlist = py310,pep8
 skipsdist = False
 ignore_basepython_conflict = True
 
+# specify virtualenv here to keep local runs consistent with the
+# gate (it sets the versions of pip, setuptools, and wheel)
+requires =
+    virtualenv<20.38
+
 [testenv]
 usedevelop = True
 basepython = python3


### PR DESCRIPTION
These are optional so should not be part of the requirements which are always installed. Also fix the inconsistent lower constraints of horizon described in different files.

Change-Id: I97fb056d8519d7020720b11484cf6cf03ef87090

---

Backport from upstream stable/2025.1, hopefully will result in no longer having horizon installed in all our neutron images.